### PR TITLE
Support v1.22+ k8s

### DIFF
--- a/.github/workflows/helm-charts-test.yaml
+++ b/.github/workflows/helm-charts-test.yaml
@@ -9,6 +9,7 @@ jobs:
       matrix:
         # node image versions for helm/kind-action@v1.2.0 => kubernetes-sigs/kind@0.11.1 (https://github.com/kubernetes-sigs/kind/releases/tag/v0.11.1)
         node_image_version: [v1.21.1, v1.22.0]
+    name: lint-test (k8s ${{ matrix.node_image_version }})
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/helm-charts-test.yaml
+++ b/.github/workflows/helm-charts-test.yaml
@@ -5,6 +5,10 @@ on: pull_request
 jobs:
   lint-test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # node image versions for helm/kind-action@v1.2.0 => kubernetes-sigs/kind@0.11.1 (https://github.com/kubernetes-sigs/kind/releases/tag/v0.11.1)
+        node_image_version: [v1.21.1, v1.22.0]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -38,12 +42,14 @@ jobs:
 
       - name: Create kind cluster
         uses: helm/kind-action@v1.2.0
+        with:
+          node_image: kindest/node:${{ matrix.node_image_version }}
         if: steps.list-changed.outputs.changed == 'true'
 
       # Our Enterprise chart requires some resources created
       - name: Create Enterprise Test Resources
         run: |
-          kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v0.15.1/cert-manager.yaml
+          kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v1.5.4/cert-manager.yaml
           sleep 30 # wait for CertManager
           kubectl apply -f ./charts/influxdb-enterprise/example-resources.yaml
           kubectl create secret generic influxdb-license --from-literal=INFLUXDB_ENTERPRISE_LICENSE_KEY=${INFLUXDB_ENTERPRISE_LICENSE_KEY}
@@ -53,7 +59,6 @@ jobs:
 
       - name: Run chart-testing (install)
         run: ct install --namespace=default
-
 # When https://github.com/helm/chart-testing/issues/212 is fixed, this can be used to set the license key instead of using env from secret
 #        run: ct install --namespace=default --helm-extra-args="--set license.key=${INFLUXDB_ENTERPRISE_LICENSE_KEY}"
 #        env:

--- a/.github/workflows/helm-charts-test.yaml
+++ b/.github/workflows/helm-charts-test.yaml
@@ -7,10 +7,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # node image versions for helm/kind-action@v1.2.0 => kubernetes-sigs/kind@0.11.1 (https://github.com/kubernetes-sigs/kind/releases/tag/v0.11.1)
         node_image_version:
-          - v1.21.1 # default used by helm/kind-action@v1.2.0 => kubernetes-sigs/kind@0.11.1
-          - v1.22.0
+          - v1.21.1 # default used by helm/kind-action@v1.2.0 (kubernetes-sigs/kind@0.11.1)
+          - v1.22.4
     name: lint-test (k8s ${{ matrix.node_image_version }})
     steps:
       - name: Checkout

--- a/.github/workflows/helm-charts-test.yaml
+++ b/.github/workflows/helm-charts-test.yaml
@@ -8,7 +8,9 @@ jobs:
     strategy:
       matrix:
         # node image versions for helm/kind-action@v1.2.0 => kubernetes-sigs/kind@0.11.1 (https://github.com/kubernetes-sigs/kind/releases/tag/v0.11.1)
-        node_image_version: [v1.21.1, v1.22.0]
+        node_image_version:
+          - v1.21.1 # default used by helm/kind-action@v1.2.0 => kubernetes-sigs/kind@0.11.1
+          - v1.22.0
     name: lint-test (k8s ${{ matrix.node_image_version }})
     steps:
       - name: Checkout

--- a/charts/chronograf/Chart.yaml
+++ b/charts/chronograf/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: chronograf
-version: 1.2.1
+version: 1.2.2
 appVersion: 1.9.1
 description: Open-source web application written in Go and React.js that provides
   the tools to visualize your monitoring data and easily create alerting and automation

--- a/charts/chronograf/templates/ingress.yaml
+++ b/charts/chronograf/templates/ingress.yaml
@@ -1,5 +1,9 @@
 {{- if .Values.ingress.enabled -}}
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
+apiVersion: networking.k8s.io/v1
+{{- else }}
 apiVersion: networking.k8s.io/v1beta1
+{{- end }}
 kind: Ingress
 metadata:
   name: {{ template "chronograf.fullname" . }}
@@ -25,7 +29,17 @@ spec:
     http:
       paths:
       - path: {{ .Values.ingress.path }}
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
+        pathType: Prefix
+{{- end }}
         backend:
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
+          service:
+            name: {{ include "chronograf.fullname" . }}
+            port:
+              number: 80
+{{- else }}
           serviceName: {{ template "chronograf.fullname" . }}
           servicePort: 80
+{{- end }}
 {{- end -}}

--- a/charts/influxdb/Chart.yaml
+++ b/charts/influxdb/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: influxdb
-version: 4.10.5
+version: 4.10.6
 appVersion: 1.8.10
 description: Scalable datastore for metrics, events, and real-time analytics.
 keywords:

--- a/charts/influxdb/templates/backup-cronjob.yaml
+++ b/charts/influxdb/templates/backup-cronjob.yaml
@@ -1,5 +1,9 @@
 {{- if .Values.backup.enabled }}
+{{- if .Capabilities.APIVersions.Has "batch/v1" }}
+apiVersion: batch/v1
+{{- else }}
 apiVersion: batch/v1beta1
+{{- end }}
 kind: CronJob
 metadata:
   name: {{ include "influxdb.fullname" . }}-backup

--- a/charts/influxdb/templates/backup-retention-cronjob.yaml
+++ b/charts/influxdb/templates/backup-retention-cronjob.yaml
@@ -1,5 +1,9 @@
 {{- if .Values.backupRetention.enabled }}
+{{- if .Capabilities.APIVersions.Has "batch/v1" }}
+apiVersion: batch/v1
+{{- else }}
 apiVersion: batch/v1beta1
+{{- end }}
 kind: CronJob
 metadata:
   name: {{ include "influxdb.fullname" . }}-backup-retention

--- a/charts/influxdb2/Chart.yaml
+++ b/charts/influxdb2/Chart.yaml
@@ -1,11 +1,10 @@
 apiVersion: v2
 appVersion: 2.1.1
-
 name: influxdb2
 description: A Helm chart for InfluxDB v2
 home: https://www.influxdata.com/products/influxdb/
 type: application
-version: 2.0.8
+version: 2.0.9
 maintainers:
   - name: rawkode
     email: rawkode@influxdata.com

--- a/charts/influxdb2/templates/pdb.yaml
+++ b/charts/influxdb2/templates/pdb.yaml
@@ -1,10 +1,14 @@
 {{- if .Values.pdb.create }}
+{{- if .Capabilities.APIVersions.Has "policy/v1" }}
+apiVersion: policy/v1
+{{- else }}
 apiVersion: policy/v1beta1
+{{- end }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "influxdb.fullname" . }}
   labels:
-  {{ include "influxdb.labels" . | nindent 4 }}
+  {{- include "influxdb.labels" . | nindent 4 }}
 spec:
   {{- if .Values.pdb.minAvailable }}
   minAvailable: {{ .Values.pdb.minAvailable }}

--- a/charts/kapacitor/Chart.yaml
+++ b/charts/kapacitor/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kapacitor
-version: 1.4.2
+version: 1.4.3
 appVersion: 1.6.3
 description: InfluxDB's native data processing engine. It can process both stream
   and batch data from InfluxDB.

--- a/charts/kapacitor/templates/role.yaml
+++ b/charts/kapacitor/templates/role.yaml
@@ -1,5 +1,9 @@
 {{- if and .Values.rbac.create .Values.rbac.namespaced -}}
+{{- if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1" }}
+apiVersion: rbac.authorization.k8s.io/v1
+{{- else }}
 apiVersion: rbac.authorization.k8s.io/v1beta1
+{{- end }}
 kind: Role
 metadata:
   name: {{ template "kapacitor.fullname" . }}

--- a/charts/kapacitor/templates/rolebinding.yaml
+++ b/charts/kapacitor/templates/rolebinding.yaml
@@ -1,5 +1,9 @@
 {{- if and .Values.rbac.create .Values.rbac.namespaced -}}
+{{- if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1" }}
+apiVersion: rbac.authorization.k8s.io/v1
+{{- else }}
 apiVersion: rbac.authorization.k8s.io/v1beta1
+{{- end }}
 kind: RoleBinding
 metadata:
   name: {{ template "kapacitor.fullname" . }}

--- a/charts/telegraf/Chart.yaml
+++ b/charts/telegraf/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: telegraf
-version: 1.8.13
-appVersion: 1.21.2
+version: 1.8.14
+appVersion: 1.21.3
 deprecated: false
 description: Telegraf is an agent written in Go for collecting, processing, aggregating, and writing metrics.
 keywords:

--- a/charts/telegraf/templates/pdb.yaml
+++ b/charts/telegraf/templates/pdb.yaml
@@ -1,5 +1,9 @@
 {{- if .Values.pdb.create }}
+{{- if .Capabilities.APIVersions.Has "policy/v1" }}
+apiVersion: policy/v1
+{{- else }}
 apiVersion: policy/v1beta1
+{{- end }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "telegraf.fullname" . }}


### PR DESCRIPTION
- extends checks to run also with v1.22 k8s, where several `v1beta1` APIs have been removed, and
- adds support for `v1` APIs

Until now, test ran on v1.21.1 (apparently some default by used `helm/kind-action@v1.2.0` or `kubernetes-sigs/kind@0.11.1` respectively). This is kept (the version explicitly listed).